### PR TITLE
[Refactor] Remove config for some LTune modules

### DIFF
--- a/endure.toml
+++ b/endure.toml
@@ -312,8 +312,6 @@ norm_layer = "Batch"
 
 categorical_mode = "reinmax"
 
-k_clip = true
-
 # kwargs specific to LTune models during forward pass
 [ltune.model.train_kwargs]
 temp = 1

--- a/endure/ltune/data/dataset.py
+++ b/endure/ltune/data/dataset.py
@@ -1,44 +1,33 @@
 import glob
-import logging
 import numpy as np
 import os
 import pandas as pd
 import pyarrow.parquet as pa
 import torch
 import torch.utils.data
-from typing import Any
+
+from endure.ltune.data.input_features import kINPUT_FEATS
 
 
-class LTuneIterableDataSet(torch.utils.data.IterableDataset):
+class LTuneDataSet(torch.utils.data.IterableDataset):
     def __init__(
         self,
-        config: dict[str, Any],
         folder: str,
         format: str = "parquet",
         shuffle: bool = False,
-    ):
-        self.log = logging.getLogger(config["log"]["name"])
-        self._config = config
+    ) -> None:
         self._format = format
         self._fnames = glob.glob(os.path.join(folder, "*." + format))
         self._shuffle = shuffle
 
     def _get_input_cols(self):
-        return self._config["ltune"]["input_features"]
+        return kINPUT_FEATS
 
     def _load_data(self, fname):
         if self._format == "parquet":
             df = pa.read_table(fname).to_pandas()
         else:
             df = pd.read_csv(fname)
-        if self._config["ltune"]["data"]["normalize_inputs"]:
-            df = self._normalize_df(df)
-
-        return df
-
-    def _normalize_df(self, df):
-        df[["z0", "z1", "q", "w"]] -= [0.5, 0.5, 0.5, 0.5]
-        df[["z0", "z1", "q", "w"]] /= [0.3, 0.3, 0.3, 0.3]
 
         return df
 

--- a/endure/ltune/data/input_features.py
+++ b/endure/ltune/data/input_features.py
@@ -1,0 +1,16 @@
+kSYSTEM_HEADER = [
+    "entry_p_page",
+    "selec",
+    "entry_size",
+    "max_h",
+    "num_elem"
+]
+
+kWORKLOAD_HEADER = [
+    "z0",
+    "z1",
+    "q",
+    "w",
+]
+
+kINPUT_FEATS = kSYSTEM_HEADER + kWORKLOAD_HEADER

--- a/endure/ltune/loss.py
+++ b/endure/ltune/loss.py
@@ -6,6 +6,7 @@ from torch import Tensor
 import toml
 
 from endure.lcm.model.builder import LearnedCostModelBuilder
+from endure.lsm.types import STR_POLICY_DICT
 
 
 class LearnedCostModelLoss(torch.nn.Module):
@@ -24,7 +25,9 @@ class LearnedCostModelLoss(torch.nn.Module):
             max_levels=lcm_cfg["lsm"]["max_levels"],
             **lcm_cfg["lcm"]["model"],
         )
-        lcm_model = lcm_cfg["job"]["LCMTrain"]["model"]
+        lcm_model = STR_POLICY_DICT.get(lcm_cfg["lsm"]["design"], None)
+        if lcm_model is None:
+            raise TypeError(f"Illegal LCM model choice: {lcm_model=}")
         self.model = self.lcm_builder.build_model(lcm_model)
 
         data = torch.load(

--- a/endure/ltune/util/ltune_eval.py
+++ b/endure/ltune/util/ltune_eval.py
@@ -7,7 +7,7 @@ import torch
 from endure.lcm.util import eval_lcm_impl
 from endure.lsm.cost import EndureCost
 from endure.lsm.types import LSMDesign, System, Policy, STR_POLICY_DICT
-from endure.ltune.data.generator import LTuneGenerator
+from endure.ltune.data.generator import LTuneDataGenerator
 from endure.ltune.loss import LearnedCostModelLoss
 import endure.lsm.solver as Solver
 
@@ -20,7 +20,7 @@ class LTuneEvalUtil:
         design_type: str = "Level",
     ) -> None:
         self.policy = STR_POLICY_DICT.get(design_type, Policy.KHybrid)
-        self.gen = LTuneGenerator(config)
+        self.gen = LTuneDataGenerator()
         self.loss = LearnedCostModelLoss(
             config,
             config["job"]["LTuneTrain"]["loss_fn_path"]

--- a/jobs/ltune_data_gen.py
+++ b/jobs/ltune_data_gen.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from endure.data.io import Reader
-from endure.ltune.data.generator import LTuneGenerator
+from endure.ltune.data.generator import LTuneDataGenerator
 
 
 class LTuneDataGenJob:
@@ -23,7 +23,7 @@ class LTuneDataGenJob:
         )
 
     def _choose_generator(self):
-        return LTuneGenerator(self.config)
+        return LTuneDataGenerator()
 
     def generate_csv_file(self, generator, idx: int, pos: int) -> int:
         fname_prefix = self.setting["file_prefix"]
@@ -52,7 +52,7 @@ class LTuneDataGenJob:
         return idx
 
     def generate_parquet_file(
-        self, generator: LTuneGenerator, idx: int, pos: int
+        self, generator: LTuneDataGenerator, idx: int, pos: int
     ) -> int:
         fname_prefix = self.setting["file_prefix"]
         fname = f"{fname_prefix}-{idx:04}.parquet"
@@ -71,7 +71,7 @@ class LTuneDataGenJob:
             ncols=80,
             disable=self.config["log"]["disable_tqdm"],
         ):
-            table.append(generator.generate_row_parquet())
+            table.append(generator.generate_row())
         table = pa.Table.from_pylist(table)
         pq.write_table(table, fpath)
 

--- a/jobs/ltune_train.py
+++ b/jobs/ltune_train.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Optional
 import torch.optim as Opt
 from torch.utils.data import DataLoader
 
-from endure.ltune.data.dataset import LTuneIterableDataSet
+from endure.ltune.data.dataset import LTuneDataSet
 from endure.ltune.loss import LearnedCostModelLoss
 from endure.ltune.model.builder import LTuneModelBuilder
 from endure.util.lr_scheduler import LRSchedulerBuilder
@@ -56,8 +56,7 @@ class LTuneTrainJob:
             self._config["io"]["data_dir"],
             self._setting["train"]["dir"],
         )
-        train_data = LTuneIterableDataSet(
-            config=self._config,
+        train_data = LTuneDataSet(
             folder=train_dir,
             shuffle=self._setting["train"]["shuffle"],
             format=self._setting["train"]["format"],
@@ -78,8 +77,7 @@ class LTuneTrainJob:
             self._config["io"]["data_dir"],
             self._setting["test"]["dir"],
         )
-        test_data = LTuneIterableDataSet(
-            config=self._config,
+        test_data = LTuneDataSet(
             folder=test_dir,
             shuffle=self._setting["test"]["shuffle"],
             format=self._setting["test"]["format"],

--- a/jobs/ltune_train.py
+++ b/jobs/ltune_train.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Optional
 import torch.optim as Opt
 from torch.utils.data import DataLoader
 
+from endure.lsm.types import STR_POLICY_DICT
 from endure.ltune.data.dataset import LTuneDataSet
 from endure.ltune.loss import LearnedCostModelLoss
 from endure.ltune.model.builder import LTuneModelBuilder
@@ -23,6 +24,11 @@ class LTuneTrainJob:
         self.log = logging.getLogger(self._config["log"]["name"])
         self.log.info("Running Training Job")
 
+        policy = STR_POLICY_DICT.get(self._config["lsm"]["design"], None)
+        if policy is None:
+            raise TypeError(f"Invalid LSM Design")
+        self.policy = policy
+
     def _build_loss_fn(self) -> torch.nn.Module:
         model = LearnedCostModelLoss(self._config, self._setting["loss_fn_path"])
         if self._setting["use_gpu_if_avail"] and torch.cuda.is_available():
@@ -31,7 +37,18 @@ class LTuneTrainJob:
         return model
 
     def _build_model(self) -> torch.nn.Module:
-        model = LTuneModelBuilder(self._config).build_model()
+        size_ratio_min = self._config["lsm"]["size_ratio"]["min"]
+        size_ratio_max = self._config["lsm"]["size_ratio"]["max"]
+        builder = LTuneModelBuilder(
+            hidden_width=self._config["ltune"]["model"]["hidden_width"],
+            hidden_length=self._config["ltune"]["model"]["hidden_length"],
+            dropout=self._config["ltune"]["model"]["dropout"],
+            norm_layer=self._config["ltune"]["model"]["norm_layer"],
+            categorical_mode=self._config["ltune"]["model"]["categorical_mode"],
+            size_ratio_range=(size_ratio_min, size_ratio_max),
+            max_levels=self._config["lsm"]["max_levels"],
+        )
+        model = builder.build_model(self.policy)
         if self._setting["use_gpu_if_avail"] and torch.cuda.is_available():
             model.to("cuda")
 


### PR DESCRIPTION
# Context

We slowly want to remove the reliance on the dictionary configuration being passed around all modules. We should try to take the approach of writing a library, then using the library in our jobs to do experiment logic etc. This should lead to better development time and less configuration knobs.