### PR TITLE
[Refactor] Use LSMBounds for generator

### DIFF
--- a/endure/lsm/types.py
+++ b/endure/lsm/types.py
@@ -45,9 +45,14 @@ class LSMDesign:
 
 @dataclass
 class LSMBounds:
-    max_levels: int = 20
-    bpe: Tuple[float, float] = (1.0, 10.0)
-    size_ratio: Tuple[float, float] = (2, 31)
+    max_considered_levels: int = 20
+    bits_per_elem_range: Tuple[int, int] = (1, 10)
+    size_ratio_range: Tuple[int, int] = (2, 31)
+    page_sizes: Tuple = (4, 8, 16)
+    entry_sizes: Tuple = (1024, 2048, 4096, 8192)
+    memory_budget_range: Tuple[float, float] = (5.0, 20.0)
+    selectivity_range: Tuple[float, float] = (1e-7, 1e-9)
+    elements_range: Tuple[int, int] = (100000000, 1000000000)
 
 
 @dataclass

--- a/jobs/lcm_data_gen.py
+++ b/jobs/lcm_data_gen.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from endure.data.io import Reader
-from endure.lsm.types import Policy
+from endure.lsm.types import Policy, LSMBounds
 import endure.lcm.data.generator as Generators
 
 
@@ -26,16 +26,17 @@ class LCMDataGenJob:
     def _choose_generator(self) -> Generators.LCMDataGenerator:
         choice = self.setting["generator"]
         max_levels = self.config["lsm"]["max_levels"]
+        bounds = LSMBounds()
         generators = {
             "TierCost": Generators.ClassicGenerator(
-                policies=[Policy.Tiering], max_levels=max_levels
+                bounds, policies=[Policy.Tiering], max_levels=max_levels
             ),
             "LevelCost": Generators.ClassicGenerator(
-                policies=[Policy.Leveling], max_levels=max_levels
+                bounds, policies=[Policy.Leveling], max_levels=max_levels
             ),
-            "QCost": Generators.QCostGenerator(max_levels=max_levels),
-            "KHybridCost": Generators.KHybridGenerator(max_levels=max_levels),
-            "ClassicCost": Generators.ClassicGenerator(max_levels=max_levels),
+            "QCost": Generators.QCostGenerator(bounds, max_levels=max_levels),
+            "KHybridCost": Generators.KHybridGenerator(bounds, max_levels=max_levels),
+            "ClassicCost": Generators.ClassicGenerator(bounds, max_levels=max_levels),
         }
         generator = generators.get(choice, None)
         if generator is None:


### PR DESCRIPTION
Introduce LSMBounds object to be passed around for data generator. Additionally, we may find extra uses for this in solvers/problem definitions.